### PR TITLE
[DNM] feat(1650): eslint rules improvement.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = {
         'no-bitwise': 'error',
         'no-multiple-empty-lines': ['error', { max: 1 }],
         'no-param-reassign': ['error', { props: false }],
+        'prefer-destructuring': 'warn',
         'prefer-rest-params': 'off',
         'prefer-spread': 'off',
         'prettier/prettier': [

--- a/index.js
+++ b/index.js
@@ -20,17 +20,23 @@ module.exports = {
         complexity: 'warn',
         eqeqeq: ['error', 'always'],
         'import/newline-after-import': ['off'],
-        'import/no-extraneous-dependencies': ['error', {
-            devDependencies: true,
-            optionalDependencies: false,
-            peerDependencies: false
-        }],
+        'import/no-extraneous-dependencies': [
+            'error',
+            {
+                devDependencies: true,
+                optionalDependencies: false,
+                peerDependencies: false
+            }
+        ],
         indent: ['error', 4],
         'max-len': ['error', { code: 100, ignoreComments: true }],
         'max-lines-per-function': 'warn',
         'max-params': 'warn',
         'max-statements': 'warn',
-        'new-cap': ['error', { capIsNewExceptions: ['Given', 'When', 'Then', 'Before', 'After'] }],
+        'new-cap': [
+            'error',
+            { capIsNewExceptions: ['Given', 'When', 'Then', 'Before', 'After'] }
+        ],
         'newline-after-var': ['error', 'always'],
         'newline-before-return': 'error',
         'no-bitwise': 'error',
@@ -45,13 +51,16 @@ module.exports = {
                 tabWidth: 4
             }
         ],
-        'require-jsdoc': ['error', {
-            require: {
-                FunctionDeclaration: true,
-                MethodDefinition: false,
-                ClassDeclaration: false
+        'require-jsdoc': [
+            'error',
+            {
+                require: {
+                    FunctionDeclaration: true,
+                    MethodDefinition: false,
+                    ClassDeclaration: false
+                }
             }
-        }],
+        ],
         strict: ['error', 'safe']
     }
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 'use strict';
 
 module.exports = {
-    extends: 'airbnb-base',
+    extends: [
+        'airbnb-base',
+        'plugin:prettier/recommended' // last one wins
+    ],
     env: {
         browser: true,
         es6: true,
@@ -14,6 +17,7 @@ module.exports = {
     rules: {
         'comma-dangle': ['error', 'never'],
         'class-methods-use-this': 'off',
+        complexity: 'warn',
         eqeqeq: ['error', 'always'],
         'import/newline-after-import': ['off'],
         'import/no-extraneous-dependencies': ['error', {
@@ -23,6 +27,9 @@ module.exports = {
         }],
         indent: ['error', 4],
         'max-len': ['error', { code: 100, ignoreComments: true }],
+        'max-lines-per-function': 'warn',
+        'max-params': 'warn',
+        'max-statements': 'warn',
         'new-cap': ['error', { capIsNewExceptions: ['Given', 'When', 'Then', 'Before', 'After'] }],
         'newline-after-var': ['error', 'always'],
         'newline-before-return': 'error',
@@ -31,6 +38,13 @@ module.exports = {
         'no-param-reassign': ['error', { props: false }],
         'prefer-rest-params': 'off',
         'prefer-spread': 'off',
+        'prettier/prettier': [
+            'error',
+            {
+                singleQuote: true,
+                tabWidth: 4
+            }
+        ],
         'require-jsdoc': ['error', {
             require: {
                 FunctionDeclaration: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -373,6 +373,14 @@
         "object.entries": "^1.0.4"
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz",
+      "integrity": "sha512-vDrcCFE3+2ixNT5H83g28bO/uYAwibJxerXPj+E7op4qzBCsAV36QfvdAyVOoNxKAH2Os/e01T/2x++V0LPukA==",
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -462,6 +470,14 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
+      "integrity": "sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==",
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-restricted-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
@@ -542,6 +558,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -609,6 +630,11 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
     },
     "glob": {
       "version": "7.1.3",
@@ -3846,6 +3872,19 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "progress": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
   "dependencies": {
     "eslint": "^5.8.0",
     "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.14.0"
+    "eslint-config-prettier": "^6.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-prettier": "^3.1.0",
+    "prettier": "^1.18.2"
   }
 }


### PR DESCRIPTION
## 概要

Eslintルールの改善提案PRです。本家に出す前のディスカッション用です。
- eslint-config-screwdriver-4.0 で eslint はすでに 5.8 に上がっている。追加されたルール等はそのまま尊重する。
- `prettier` の導入: フォーマットは prettier に、構文チェックは eslint に任せる
- 長めの関数実装に警告を出すための設定を追加（最初の提案）
- 本質的ではないdiffが大量に出るのを抑止する（クォーティング、インデント等）。それ以外はデフォルト設定を可能な限り尊重。

## 懸念点
- この更新により、ソース修正のコストが高まるか？
    - `eslint --fix` でほとんどのものが自動修正できるのでそれほど問題ではない。APIの場合、手動修正が必要になるのは3つのエラーのみ。eslint を上げたのに、追加ルールを無効にしまくるのも何なので。

## 各リポジトリへの展開について
- まだ `eslint-config-screwdriver@^4.0.0` を利用していないリポジトリが多いので、このPRマージ後にそれらのリポジトリに `^4.0.0` 系を展開するとよいでしょう。
- diff が比較的多めに出るので実施タイミングは考慮した方がよいです。
- `eslint --fix` でほとんどの修正を実施し、残った少数のエラーは手動で修正することになります。

## 参考
議論はこちら
- https://github.com/screwdriver-cd/screwdriver/issues/1650